### PR TITLE
Added rate limiter (removed by mistake)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -27,6 +27,14 @@ valid_games = [
     "RAINBOW_SIX"
 ]
 
+#Rate limiter config
+message_limit = 3
+cooldown_seconds = 30
+#Rate limiter global variables
+message_count = 0
+previous_author = None
+previous_timestamp = None
+
 parser = argparse.ArgumentParser(description="Handle the #on_hand_volunteers channel.")
 parser.add_argument("-v", "--verbose", dest="verbose", action="store_const",
                     const=True, default=False,
@@ -667,5 +675,34 @@ async def on_message(message):
             await client.send_file(message.channel, 'dennis.gif')
             await client.send_message(message.channel, msg)
 
+    #Rate limiter
+    if message.channel.name == "nsfw_shitposting":
+        global previous_author
+        global message_count
+        global previous_timestamp
+        #Get seconds since first message after start of cooldown
+        try:
+            delta = message.timestamp - previous_timestamp
+            delta = delta.seconds
+        except TypeError:
+            delta = 0
+        #Reset count if cooldown has been reached or new author has posted
+        if delta > cooldown_seconds or message.author != previous_author:
+            message_count = 0;
+            previous_timestamp = message.timestamp
+            delta = 0
+        previous_author = message.author
+        #Increment count by number of attachments, if any. Otherwise, increment by 1.
+        if len(message.attachments) > 1:
+            message_count = message_count + len(message.attachments)
+        else:
+            message_count = message_count + 1
+        #If count is 5 or more, berate them
+        if message_count > message_limit:
+            msg = "**Error 429: DUMP DETECTED :poo:**\n{0}, you may not be breaking any rules, but you are being a scumbag.".format(message.author.mention)
+            await client.send_message(message.channel, msg)
+            log.info("[{0}] hit rate limit with {1} posts in [{2}] within {3} seconds".format(message.author, message_count, message.channel, delta))
+            message_count = 0
+            previous_timestamp = message.timestamp        
 
 client.run(args.token)


### PR DESCRIPTION
Kindly berates members who post dumps or spam the channel
Configured by message_limit and cooldown_seconds
Resets counter if two or more members are involved in dialogue
Only monitors nsfw_shitposting channel