### PR TITLE
Fixed some bugs from the docker branch

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -52,7 +52,7 @@ def is_silly_channel(ctx):
 
 
 def get_guild():
-    return bot.get_guild(os.environ['DISCORD_TOKEN'])
+    return bot.get_guild(int(os.environ['DISCORD_GUILD_ID']))
 
 
 def get_channel(name):

--- a/config.yaml
+++ b/config.yaml
@@ -52,6 +52,8 @@ channels:
         - promote_a_stream
         - looking_for_game
         - w4l_merch
+    rate_limited:
+        - nsfw_shitposting
 answers:
     True:
         - "absolutely"
@@ -122,6 +124,6 @@ statuses:
     - 2the field
     - 2possum
     - 2footsie
-    
+
 secret_senpai_exclusions:
     senpai_id: kohai_id


### PR DESCRIPTION
- get_guild() was using the wrong env variable
- guild ids are now intergers so we must cast to int first
- config.yaml was missing channels/rate_limited category (necessary for rude rate limiter)